### PR TITLE
[WEB-773]  user marketing communication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ jobs:
   include:
     - stage: "API smoke test"
       name: "QA1"
-      script: node_modules/.bin/newman run tests/API_smoke_test.postman_collection.json -e tests/QA1.postman_environment.json --env-var "loginEmail=$QA1_USER_EMAIL" --env-var "loginPw=$QA1_USER_PASSWORD"
-    - script: node_modules/.bin/newman run tests/API_smoke_test.postman_collection.json -e tests/QA2.postman_environment.json --env-var "loginEmail=$QA2_USER_EMAIL" --env-var "loginPw=$QA2_USER_PASSWORD"
+      script: node_modules/.bin/newman run tests/API_smoke_test.postman_collection.json -e tests/QA1.postman_environment.json --env-var "loginEmail=$QA1_USER_EMAIL" --env-var "loginPw=$QA1_USER_PASSWORD" --env-var "marketoClientId=$MARKETO_CLIENT_ID" --env-var "marketoClientSecret=$MARKETO_CLIENT_SECRET"
+    - script: node_modules/.bin/newman run tests/API_smoke_test.postman_collection.json -e tests/QA2.postman_environment.json --env-var "loginEmail=$QA2_USER_EMAIL" --env-var "loginPw=$QA2_USER_PASSWORD" --env-var "marketoClientId=$MARKETO_CLIENT_ID" --env-var "marketoClientSecret=$MARKETO_CLIENT_SECRET"
       name: "QA2"
-    - script: node_modules/.bin/newman run tests/API_smoke_test.postman_collection.json -e tests/PRODUCTION.postman_environment.json --env-var "loginEmail=$PRODUCTION_USER_EMAIL" --env-var "loginPw=$PRODUCTION_USER_PASSWORD"
+    - script: node_modules/.bin/newman run tests/API_smoke_test.postman_collection.json -e tests/PRODUCTION.postman_environment.json --env-var "loginEmail=$PRODUCTION_USER_EMAIL" --env-var "loginPw=$PRODUCTION_USER_PASSWORD" --env-var "marketoClientId=$MARKETO_CLIENT_ID" --env-var "marketoClientSecret=$MARKETO_CLIENT_SECRET"
       name: "PRODUCTION"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ jobs:
   include:
     - stage: "API smoke test"
       name: "QA1"
-      script: node_modules/.bin/newman run tests/API_smoke_test.postman_collection.json -e tests/QA1.postman_environment.json --env-var "loginEmail=$QA1_USER_EMAIL" --env-var "loginPw=$QA1_USER_PASSWORD" --env-var "marketoClientId=$MARKETO_CLIENT_ID" --env-var "marketoClientSecret=$MARKETO_CLIENT_SECRET"
-    - script: node_modules/.bin/newman run tests/API_smoke_test.postman_collection.json -e tests/QA2.postman_environment.json --env-var "loginEmail=$QA2_USER_EMAIL" --env-var "loginPw=$QA2_USER_PASSWORD" --env-var "marketoClientId=$MARKETO_CLIENT_ID" --env-var "marketoClientSecret=$MARKETO_CLIENT_SECRET"
+      script: node_modules/.bin/newman run tests/API_smoke_test.postman_collection.json -e tests/QA1.postman_environment.json --env-var "loginEmail=$QA1_USER_EMAIL" --env-var "loginPw=$QA1_USER_PASSWORD" --env-var "marketoClientId=$MARKETO_CLIENT_ID" --env-var "marketoClientSecret=$MARKETO_CLIENT_SECRET" --env-var "marketoEmailPw=$MARKETO_EMAIL_PASSWORD"
+    - script: node_modules/.bin/newman run tests/API_smoke_test.postman_collection.json -e tests/QA2.postman_environment.json --env-var "loginEmail=$QA2_USER_EMAIL" --env-var "loginPw=$QA2_USER_PASSWORD" --env-var "marketoClientId=$MARKETO_CLIENT_ID" --env-var "marketoClientSecret=$MARKETO_CLIENT_SECRET" --env-var "marketoEmailPw=$MARKETO_EMAIL_PASSWORD"
       name: "QA2"
-    - script: node_modules/.bin/newman run tests/API_smoke_test.postman_collection.json -e tests/PRODUCTION.postman_environment.json --env-var "loginEmail=$PRODUCTION_USER_EMAIL" --env-var "loginPw=$PRODUCTION_USER_PASSWORD" --env-var "marketoClientId=$MARKETO_CLIENT_ID" --env-var "marketoClientSecret=$MARKETO_CLIENT_SECRET"
+    - script: node_modules/.bin/newman run tests/API_smoke_test.postman_collection.json -e tests/PRODUCTION.postman_environment.json --env-var "loginEmail=$PRODUCTION_USER_EMAIL" --env-var "loginPw=$PRODUCTION_USER_PASSWORD" --env-var "marketoClientId=$MARKETO_CLIENT_ID" --env-var "marketoClientSecret=$MARKETO_CLIENT_SECRET" --env-var "marketoEmailPw=$MARKETO_EMAIL_PASSWORD"
       name: "PRODUCTION"

--- a/tests/API_smoke_test.postman_collection.json
+++ b/tests/API_smoke_test.postman_collection.json
@@ -342,16 +342,6 @@
 								],
 								"type": "text/javascript"
 							}
-						},
-						{
-							"listen": "prerequest",
-							"script": {
-								"id": "3433a954-3a9e-49f4-a76b-3dd76c7b493a",
-								"exec": [
-									""
-								],
-								"type": "text/javascript"
-							}
 						}
 					],
 					"request": {
@@ -479,7 +469,10 @@
 									"const assert = eval(globals.loadAsserts);",
 									"assert.common(200, 1000, false, null, \"\");",
 									"let jsonData = pm.response.json();",
-									"pm.variables.set(\"marketoAccessToken\", jsonData.access_token);"
+									"pm.variables.set(\"marketoAccessToken\", jsonData.access_token);",
+									"if (pm.environment.get('api') == \"https://stg-api.tidepool.org\"){",
+									"    postman.setNextRequest(\"Retrieve paging token for the last 12 hours\");",
+									"};"
 								],
 								"type": "text/javascript"
 							}
@@ -520,16 +513,6 @@
 				{
 					"name": "Get lead email address initial",
 					"event": [
-						{
-							"listen": "prerequest",
-							"script": {
-								"id": "c9f0ac6a-546d-482f-8f18-ce16a9b6e13d",
-								"exec": [
-									""
-								],
-								"type": "text/javascript"
-							}
-						},
 						{
 							"listen": "test",
 							"script": {
@@ -898,7 +881,10 @@
 									"pm.test(\"Marketo has delivered emails within the last hour\", function () {",
 									"    var jsonData = pm.response.json();",
 									"    pm.expect(jsonData.result[0].activityTypeId).to.eql(pm.variables.get(\"campaignEmailSent\"));",
-									"});"
+									"});",
+									"if (pm.environment.get('api') == \"https://stg-api.tidepool.org\"){",
+									"    postman.setNextRequest(null);",
+									"};"
 								],
 								"type": "text/javascript"
 							}
@@ -940,23 +926,12 @@
 					"name": "Get lead email address updated",
 					"event": [
 						{
-							"listen": "prerequest",
-							"script": {
-								"id": "c9f0ac6a-546d-482f-8f18-ce16a9b6e13d",
-								"exec": [
-									""
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
 							"listen": "test",
 							"script": {
 								"id": "29535b0a-7fee-42ef-8c79-2bcc5a383f94",
 								"exec": [
 									"const assert = eval(globals.loadAsserts);",
 									"assert.common(200, 1000, false, null, \"\");",
-									"",
 									"pm.test(\"Verify Lead email updated in Marketo\", function () {",
 									"    var jsonData = pm.response.json();",
 									"    pm.expect(jsonData.result[0].email).to.eql(pm.variables.get(\"newMarketoEmail\"));",
@@ -997,16 +972,6 @@
 			],
 			"description": "A series of tests designed around making sure new clinicians and DSAs are being connected via shoreline to our marketing campaigns.",
 			"event": [
-				{
-					"listen": "prerequest",
-					"script": {
-						"id": "1aa215b0-df87-4014-b78a-0236be1b78af",
-						"type": "text/javascript",
-						"exec": [
-							""
-						]
-					}
-				},
 				{
 					"listen": "test",
 					"script": {

--- a/tests/API_smoke_test.postman_collection.json
+++ b/tests/API_smoke_test.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "0a868624-bf7b-42d6-a6c7-c6aecfa24113",
+		"_postman_id": "fbc22dde-d18f-4a6e-80b4-f134bea518bb",
 		"name": "API_smoke_test",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -14,7 +14,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "5875c19d-624c-4941-b2aa-f9dc2c263109",
+								"id": "e4d13014-e96d-448d-9111-9e7e7ad6b0d4",
 								"exec": [
 									"let jsonData = pm.response.json();",
 									"pm.variables.set(\"userId\", jsonData.userid);",
@@ -78,7 +78,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "c3848609-36dc-4ef7-86d6-9a21656afffa",
+								"id": "5b06c4cb-d22f-4aaa-affd-21409f088ebb",
 								"exec": [
 									"const assert = eval(globals.loadAsserts);",
 									"assert.common(200, 300, false, pm.response.json(),\"userProfileSchema\");",
@@ -120,7 +120,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "99a4bf66-ae97-4a85-8484-6f5cd07752dd",
+								"id": "b47e6bc6-1c25-4cfc-8108-c74526b62955",
 								"exec": [
 									"const assert = eval(globals.loadAsserts);",
 									"assert.common(200, 1900, false, pm.response.json(),\"careteamInviteSchema\");"
@@ -131,7 +131,7 @@
 						{
 							"listen": "prerequest",
 							"script": {
-								"id": "046412cf-93d9-4a0f-bfb8-92d537d10a26",
+								"id": "67c1ccc0-0e8e-44f9-a0ce-886ea2da1e0b",
 								"exec": [
 									"const emailName = pm.environment.get(\"sharingEmailName\");",
 									"let emailAddress = emailName+ \"+sharing_\" + Date.now() + \"@tidepool.org\"",
@@ -178,7 +178,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "3341c83a-bc9a-4043-8c8b-8020bf5c8639",
+								"id": "315a1b8e-22d1-4abf-93b1-58bd2eb5dd2b",
 								"exec": [
 									"const assert = eval(globals.loadAsserts);",
 									"assert.common(201, 500, false, pm.response.json(),\"messageAddedSchema\");",
@@ -224,7 +224,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "72de232c-c03c-48c1-bc41-017b8aeece31",
+								"id": "49096de6-a53b-4493-a7c1-1627631c2094",
 								"exec": [
 									"const assert = eval(globals.loadAsserts);",
 									"assert.common(200, 500, false, pm.response.json().messages,\"messagesSchema\");"
@@ -265,7 +265,7 @@
 						{
 							"listen": "prerequest",
 							"script": {
-								"id": "8b9cf43a-8c79-47b0-9e17-02f9fb0214ba",
+								"id": "5eec4f64-9ca9-4b90-8c8c-4f184d1cf424",
 								"exec": [
 									"const uuid = require('uuid');",
 									"pm.variables.set(\"uploadDeviceDataItemId\", uuid.v4());",
@@ -281,7 +281,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "d0b1561e-efe4-496b-89f7-986d2badf171",
+								"id": "a21e1e5d-4c57-47bf-8a38-96791c8583c4",
 								"exec": [
 									"const assert = eval(globals.loadAsserts);",
 									"assert.common(200, 1000, false, null, \"\");"
@@ -325,7 +325,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "1e19b771-d4bf-4f62-815b-066a9cf2a7ff",
+								"id": "a72235ed-4133-4143-bdfa-540bbbbe5163",
 								"exec": [
 									"let jsonData = pm.response.json();",
 									"const assert = eval(globals.loadAsserts);",
@@ -395,7 +395,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "05a9c738-74ab-403a-9f63-7e963c699683",
+								"id": "02ffe106-2550-4588-8f2e-e2dec4073e3c",
 								"exec": [
 									"const assert = eval(globals.loadAsserts);",
 									"assert.common(200, 300, false, null, \"\");"
@@ -435,7 +435,7 @@
 				{
 					"listen": "prerequest",
 					"script": {
-						"id": "49c33b7f-2689-4615-97e2-9cae0611c109",
+						"id": "f490c89e-1add-4378-8e78-76aa9c109d81",
 						"type": "text/javascript",
 						"exec": [
 							""
@@ -445,7 +445,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "3c4b721d-fa7b-47fd-9afa-a3e644e52681",
+						"id": "263e4689-3703-45f6-89f9-d17b16c8cf54",
 						"type": "text/javascript",
 						"exec": [
 							""
@@ -464,13 +464,15 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "b756b5be-319a-406c-ba54-31f8bef6a739",
+								"id": "db7332d2-a5d2-4772-afb1-0064493b958a",
 								"exec": [
 									"const assert = eval(globals.loadAsserts);",
 									"assert.common(200, 1000, false, null, \"\");",
 									"let jsonData = pm.response.json();",
 									"pm.variables.set(\"marketoAccessToken\", jsonData.access_token);",
-									"if (pm.environment.get('api') == \"https://stg-api.tidepool.org\"){",
+									"if (pm.environment.get('api') == \"https://stg-api.tidepool.org\") {",
+									"    postman.setNextRequest(\"Retrieve paging token for the last 12 hours\");",
+									"} else if (pm.environment.get('api') == \"https://dev-api.tidepool.org\") {",
 									"    postman.setNextRequest(\"Retrieve paging token for the last 12 hours\");",
 									"};"
 								],
@@ -516,7 +518,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "29535b0a-7fee-42ef-8c79-2bcc5a383f94",
+								"id": "cc94c77d-e43d-4616-8c2d-95e04831d4f6",
 								"exec": [
 									"const assert = eval(globals.loadAsserts);",
 									"assert.common(200, 1000, false, null, \"\");",
@@ -561,7 +563,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "5875c19d-624c-4941-b2aa-f9dc2c263109",
+								"id": "a5e77262-db2c-4f38-b5ad-d95767451f36",
 								"exec": [
 									"let jsonData = pm.response.json();",
 									"pm.variables.set(\"userId\", jsonData.userid);",
@@ -624,7 +626,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "9ca1ca55-a3d4-4146-8b96-5ce198579252",
+								"id": "0612a6ff-ff5c-4c03-85ad-3cffaf1be7e5",
 								"exec": [
 									"const assert = eval(globals.loadAsserts);",
 									"assert.common(200, 500, false, null,\"\");",
@@ -637,7 +639,7 @@
 						{
 							"listen": "prerequest",
 							"script": {
-								"id": "41dbe3a9-efca-4b72-a543-b58ac98dc070",
+								"id": "ad6e657f-c9e1-4ddb-9054-88b1430336e9",
 								"exec": [
 									"var moment = require('moment');",
 									"pm.variables.set(\"currentTimestamp\", moment().unix());",
@@ -685,7 +687,7 @@
 						{
 							"listen": "prerequest",
 							"script": {
-								"id": "3afd1793-633f-4d4c-8e4a-1f43a203a145",
+								"id": "a0e28c8f-5fbd-4598-9ef6-6d3edbff9b18",
 								"exec": [
 									"var moment = require('moment');\r",
 									"pm.variables.set(\"current_timestamp\", moment().format());\r",
@@ -697,7 +699,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "598e2d2f-3f9d-4440-a3bc-4b3a0dccbf5f",
+								"id": "51239610-4980-4382-b4ec-88af7151cefa",
 								"exec": [
 									"const assert = eval(globals.loadAsserts);",
 									"assert.common(200, 1000, false, null, \"\");",
@@ -743,7 +745,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "b01b2ff1-63e9-441a-88f1-5d8dce8eeb97",
+								"id": "51f1dd2c-6dc0-4573-a195-1b608fc22a97",
 								"exec": [
 									"const assert = eval(globals.loadAsserts);",
 									"assert.common(200, 1000, false, null, \"\");",
@@ -759,7 +761,7 @@
 						{
 							"listen": "prerequest",
 							"script": {
-								"id": "77c46e9e-202a-4a47-9cae-5e0d77e03865",
+								"id": "8f529f11-ce59-47d4-a663-e3bfa958b844",
 								"exec": [
 									"pm.variables.set(\"newUserActivity\", 12);"
 								],
@@ -805,7 +807,7 @@
 						{
 							"listen": "prerequest",
 							"script": {
-								"id": "3afd1793-633f-4d4c-8e4a-1f43a203a145",
+								"id": "1818eee7-d7b6-485e-9375-7a27f87355e6",
 								"exec": [
 									"var moment = require('moment');\r",
 									"pm.variables.set(\"current_timestamp\", moment().format());\r",
@@ -817,7 +819,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "598e2d2f-3f9d-4440-a3bc-4b3a0dccbf5f",
+								"id": "3ffe6d0c-87eb-49b1-8a4a-90088e5dcf30",
 								"exec": [
 									"const assert = eval(globals.loadAsserts);",
 									"assert.common(200, 1000, false, null, \"\");",
@@ -863,7 +865,7 @@
 						{
 							"listen": "prerequest",
 							"script": {
-								"id": "9cbc4390-0752-4a23-b367-ea827ffd6f87",
+								"id": "98943c0a-1680-45c2-b3b0-7c27fca3c06f",
 								"exec": [
 									"pm.variables.set(\"campaignEmailSent\", 7);"
 								],
@@ -873,7 +875,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "cacd1abb-0016-4dbd-875d-fa5dd33c1a4e",
+								"id": "bd139c6b-b7bb-4d1a-82d9-b80c359eeefd",
 								"exec": [
 									"const assert = eval(globals.loadAsserts);",
 									"assert.common(200, 1000, false, null, \"\");",
@@ -882,7 +884,9 @@
 									"    var jsonData = pm.response.json();",
 									"    pm.expect(jsonData.result[0].activityTypeId).to.eql(pm.variables.get(\"campaignEmailSent\"));",
 									"});",
-									"if (pm.environment.get('api') == \"https://stg-api.tidepool.org\"){",
+									"if (pm.environment.get('api') == \"https://stg-api.tidepool.org\") {",
+									"    postman.setNextRequest(null);",
+									"} else if (pm.environment.get('api') == \"https://dev-api.tidepool.org\") {",
 									"    postman.setNextRequest(null);",
 									"};"
 								],
@@ -928,7 +932,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "29535b0a-7fee-42ef-8c79-2bcc5a383f94",
+								"id": "eae713a3-f55d-4cad-8f62-03737aed5ae7",
 								"exec": [
 									"const assert = eval(globals.loadAsserts);",
 									"assert.common(200, 1000, false, null, \"\");",
@@ -975,7 +979,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "07c5ca86-781b-4d89-8ac9-296f79157d76",
+						"id": "1a122569-2a89-4377-bcb5-8fecc3197dd3",
 						"type": "text/javascript",
 						"exec": [
 							""
@@ -990,7 +994,7 @@
 		{
 			"listen": "prerequest",
 			"script": {
-				"id": "85b478fc-ac96-4614-bacc-c1e101204a8b",
+				"id": "f987ed1e-6c19-4265-b810-526efc61f5c5",
 				"type": "text/javascript",
 				"exec": [
 					"const userSchema = { \"required\": [\"userid\", \"username\", \"emails\", \"emailVerified\", \"termsAccepted\"], \"properties\": { \"emailVerified\": { \"type\": \"boolean\" }, \"emails\": { \"type\": \"array\" }, \"userid\": { \"type\": \"string\" }, \"username\": { \"type\": \"string\" }, \"termsAccepted\": { \"type\": \"string\" } } };",
@@ -1064,7 +1068,7 @@
 		{
 			"listen": "test",
 			"script": {
-				"id": "45b7dd35-b3b4-4115-bbff-92d4e2158b6f",
+				"id": "b04618b8-a2c4-4490-b326-590f904d632c",
 				"type": "text/javascript",
 				"exec": [
 					""

--- a/tests/API_smoke_test.postman_collection.json
+++ b/tests/API_smoke_test.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "f44f7047-0f3d-47ef-879f-9c17c7580a5e",
+		"_postman_id": "0a868624-bf7b-42d6-a6c7-c6aecfa24113",
 		"name": "API_smoke_test",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -466,10 +466,10 @@
 			"protocolProfileBehavior": {}
 		},
 		{
-			"name": "User Marketing Communication",
+			"name": "User email notification integration",
 			"item": [
 				{
-					"name": "Retrieve marketing acess token",
+					"name": "Retrieve marketo access token",
 					"event": [
 						{
 							"listen": "test",
@@ -478,11 +478,8 @@
 								"exec": [
 									"const assert = eval(globals.loadAsserts);",
 									"assert.common(200, 1000, false, null, \"\");",
-									"",
-									"pm.test(\"Set Access Token\", function () {",
-									"    let jsonData = pm.response.json();",
-									"    pm.variables.set(\"accessToken\", jsonData.access_token);",
-									"});"
+									"let jsonData = pm.response.json();",
+									"pm.variables.set(\"marketoAccessToken\", jsonData.access_token);"
 								],
 								"type": "text/javascript"
 							}
@@ -492,12 +489,9 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "https://248-ISZ-536.mktorest.com/identity/oauth/token?grant_type=client_credentials&client_id={{marketoClientId}}&client_secret={{marketoClientSecret}}",
-							"protocol": "https",
+							"raw": "{{marketoApi}}/identity/oauth/token?grant_type=client_credentials&client_id={{marketoClientId}}&client_secret={{marketoClientSecret}}",
 							"host": [
-								"248-ISZ-536",
-								"mktorest",
-								"com"
+								"{{marketoApi}}"
 							],
 							"path": [
 								"identity",
@@ -524,6 +518,185 @@
 					"response": []
 				},
 				{
+					"name": "Get lead email address initial",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "c9f0ac6a-546d-482f-8f18-ce16a9b6e13d",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "29535b0a-7fee-42ef-8c79-2bcc5a383f94",
+								"exec": [
+									"const assert = eval(globals.loadAsserts);",
+									"assert.common(200, 1000, false, null, \"\");",
+									"let jsonData = pm.response.json();",
+									"pm.variables.set(\"currentMarketoEmail\", jsonData.result[0].email);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{marketoApi}}/rest/v1/lead/{{leadId}}.json?access_token={{marketoAccessToken}}&fields=email",
+							"host": [
+								"{{marketoApi}}"
+							],
+							"path": [
+								"rest",
+								"v1",
+								"lead",
+								"{{leadId}}.json"
+							],
+							"query": [
+								{
+									"key": "access_token",
+									"value": "{{marketoAccessToken}}"
+								},
+								{
+									"key": "fields",
+									"value": "email"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Login to tidepool",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "5875c19d-624c-4941-b2aa-f9dc2c263109",
+								"exec": [
+									"let jsonData = pm.response.json();",
+									"pm.variables.set(\"userId\", jsonData.userid);",
+									"pm.variables.set(\"sessionToken\", pm.response.headers.get(\"x-tidepool-session-token\"));",
+									"const assert = eval(globals.loadAsserts);",
+									"assert.common(200, 1000, true, jsonData,\"userSchema\");"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "{{marketoEmailPw}}",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "{{currentMarketoEmail}}",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"value": true,
+									"type": "boolean"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{api}}/auth/login",
+							"host": [
+								"{{api}}"
+							],
+							"path": [
+								"auth",
+								"login"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Change email address in Tidepool",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "9ca1ca55-a3d4-4146-8b96-5ce198579252",
+								"exec": [
+									"const assert = eval(globals.loadAsserts);",
+									"assert.common(200, 500, false, null,\"\");",
+									"let jsonData = pm.response.json();",
+									"pm.variables.set(\"newMarketoEmail\", jsonData.username);"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "41dbe3a9-efca-4b72-a543-b58ac98dc070",
+								"exec": [
+									"var moment = require('moment');",
+									"pm.variables.set(\"currentTimestamp\", moment().unix());",
+									"pm.variables.set(\"newMarketoEmail\", \"qa+automated+marketo{{currentTimestamp}}@tidepool.org.test-google-a.com\");"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "x-tidepool-session-token",
+								"type": "text",
+								"value": "{{sessionToken}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"updates\":{\"username\":\"{{newMarketoEmail}}\",\"emails\":[\"{{newMarketoEmail}}\"]}}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{api}}/auth/user",
+							"host": [
+								"{{api}}"
+							],
+							"path": [
+								"auth",
+								"user"
+							]
+						},
+						"description": "Setting up Name, clinic name, role and telephone number."
+					},
+					"response": []
+				},
+				{
 					"name": "Retrieve paging token for the last 12 hours",
 					"event": [
 						{
@@ -532,9 +705,8 @@
 								"id": "3afd1793-633f-4d4c-8e4a-1f43a203a145",
 								"exec": [
 									"var moment = require('moment');\r",
-									"\r",
-									"    pm.variables.set(\"current_timestamp\", moment().format());\r",
-									"    pm.variables.set(\"last12Hours\", moment().subtract(12, 'hours').format());"
+									"pm.variables.set(\"current_timestamp\", moment().format());\r",
+									"pm.variables.set(\"twelveHoursAgo\", moment().subtract(12, 'hours').format());"
 								],
 								"type": "text/javascript"
 							}
@@ -546,11 +718,8 @@
 								"exec": [
 									"const assert = eval(globals.loadAsserts);",
 									"assert.common(200, 1000, false, null, \"\");",
-									"",
-									"pm.test(\"Set Next Page Token for Last 12 Hours\", function (){",
-									"    let jsonData = pm.response.json();",
-									"    pm.variables.set(\"nextPageToken\", jsonData.nextPageToken);",
-									"});"
+									"let jsonData = pm.response.json();",
+									"pm.variables.set(\"nextPageToken\", jsonData.nextPageToken);"
 								],
 								"type": "text/javascript"
 							}
@@ -560,12 +729,9 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "https://248-ISZ-536.mktorest.com/rest/v1/activities/pagingtoken.json?sinceDatetime={{last12Hours}}&access_token={{accessToken}}",
-							"protocol": "https",
+							"raw": "{{marketoApi}}/rest/v1/activities/pagingtoken.json?sinceDatetime={{twelveHoursAgo}}&access_token={{marketoAccessToken}}",
 							"host": [
-								"248-ISZ-536",
-								"mktorest",
-								"com"
+								"{{marketoApi}}"
 							],
 							"path": [
 								"rest",
@@ -576,11 +742,11 @@
 							"query": [
 								{
 									"key": "sinceDatetime",
-									"value": "{{last12Hours}}"
+									"value": "{{twelveHoursAgo}}"
 								},
 								{
 									"key": "access_token",
-									"value": "{{accessToken}}"
+									"value": "{{marketoAccessToken}}"
 								}
 							]
 						},
@@ -594,15 +760,25 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "0d6e3c86-77eb-42e6-965b-c446e0d0d1c2",
+								"id": "b01b2ff1-63e9-441a-88f1-5d8dce8eeb97",
 								"exec": [
 									"const assert = eval(globals.loadAsserts);",
 									"assert.common(200, 1000, false, null, \"\");",
 									"",
 									"pm.test(\"User created within last 12 Hours\", function () {",
 									"    var jsonData = pm.response.json();",
-									"    pm.expect(jsonData.result[0].activityTypeId).to.eql(12);",
+									"    pm.expect(jsonData.result[0].activityTypeId).to.eql(pm.variables.get(\"newUserActivity\"));",
 									"});"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "77c46e9e-202a-4a47-9cae-5e0d77e03865",
+								"exec": [
+									"pm.variables.set(\"newUserActivity\", 12);"
 								],
 								"type": "text/javascript"
 							}
@@ -612,12 +788,9 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "https://248-ISZ-536.mktorest.com/rest/v1/activities.json?access_token={{accessToken}}&nextPageToken={{nextPageToken}}&activityTypeIds=12&=&&",
-							"protocol": "https",
+							"raw": "{{marketoApi}}/rest/v1/activities.json?access_token={{marketoAccessToken}}&nextPageToken={{nextPageToken}}&activityTypeIds={{newUserActivity}}",
 							"host": [
-								"248-ISZ-536",
-								"mktorest",
-								"com"
+								"{{marketoApi}}"
 							],
 							"path": [
 								"rest",
@@ -627,7 +800,7 @@
 							"query": [
 								{
 									"key": "access_token",
-									"value": "{{accessToken}}"
+									"value": "{{marketoAccessToken}}"
 								},
 								{
 									"key": "nextPageToken",
@@ -635,19 +808,7 @@
 								},
 								{
 									"key": "activityTypeIds",
-									"value": "12"
-								},
-								{
-									"key": "",
-									"value": ""
-								},
-								{
-									"key": null,
-									"value": null
-								},
-								{
-									"key": "",
-									"value": null
+									"value": "{{newUserActivity}}"
 								}
 							]
 						},
@@ -663,11 +824,9 @@
 							"script": {
 								"id": "3afd1793-633f-4d4c-8e4a-1f43a203a145",
 								"exec": [
-									"\r",
 									"var moment = require('moment');\r",
-									"\r",
-									"    pm.variables.set(\"current_timestamp\", moment().format());\r",
-									"    pm.variables.set(\"pastHour\", moment().subtract(1, 'hour').format());"
+									"pm.variables.set(\"current_timestamp\", moment().format());\r",
+									"pm.variables.set(\"oneHourAgo\", moment().subtract(1, 'hour').format());"
 								],
 								"type": "text/javascript"
 							}
@@ -679,11 +838,8 @@
 								"exec": [
 									"const assert = eval(globals.loadAsserts);",
 									"assert.common(200, 1000, false, null, \"\");",
-									"",
-									"pm.test(\"Set Next Page Token for Last 12 Hours\", function (){",
-									"    let jsonData = pm.response.json();",
-									"    pm.variables.set(\"nextPageToken\", jsonData.nextPageToken);",
-									"});"
+									"let jsonData = pm.response.json();",
+									"pm.variables.set(\"nextPageToken\", jsonData.nextPageToken);"
 								],
 								"type": "text/javascript"
 							}
@@ -693,12 +849,9 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "https://248-ISZ-536.mktorest.com/rest/v1/activities/pagingtoken.json?sinceDatetime={{pastHour}}&access_token={{accessToken}}",
-							"protocol": "https",
+							"raw": "{{marketoApi}}/rest/v1/activities/pagingtoken.json?sinceDatetime={{oneHourAgo}}&access_token={{marketoAccessToken}}",
 							"host": [
-								"248-ISZ-536",
-								"mktorest",
-								"com"
+								"{{marketoApi}}"
 							],
 							"path": [
 								"rest",
@@ -709,11 +862,11 @@
 							"query": [
 								{
 									"key": "sinceDatetime",
-									"value": "{{pastHour}}"
+									"value": "{{oneHourAgo}}"
 								},
 								{
 									"key": "access_token",
-									"value": "{{accessToken}}"
+									"value": "{{marketoAccessToken}}"
 								}
 							]
 						},
@@ -729,7 +882,7 @@
 							"script": {
 								"id": "9cbc4390-0752-4a23-b367-ea827ffd6f87",
 								"exec": [
-									""
+									"pm.variables.set(\"campaignEmailSent\", 7);"
 								],
 								"type": "text/javascript"
 							}
@@ -744,10 +897,8 @@
 									"",
 									"pm.test(\"Marketo has delivered emails within the last hour\", function () {",
 									"    var jsonData = pm.response.json();",
-									"    pm.expect(jsonData.result).to.be.an('array').that.is.not.empty;",
-									"});",
-									"",
-									"   "
+									"    pm.expect(jsonData.result[0].activityTypeId).to.eql(pm.variables.get(\"campaignEmailSent\"));",
+									"});"
 								],
 								"type": "text/javascript"
 							}
@@ -757,12 +908,9 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "https://248-ISZ-536.mktorest.com/rest/v1/activities.json?access_token={{accessToken}}&nextPageToken={{nextPageToken}}&activityTypeIds=7&=&&",
-							"protocol": "https",
+							"raw": "{{marketoApi}}/rest/v1/activities.json?access_token={{marketoAccessToken}}&nextPageToken={{nextPageToken}}&activityTypeIds={{campaignEmailSent}}",
 							"host": [
-								"248-ISZ-536",
-								"mktorest",
-								"com"
+								"{{marketoApi}}"
 							],
 							"path": [
 								"rest",
@@ -772,7 +920,7 @@
 							"query": [
 								{
 									"key": "access_token",
-									"value": "{{accessToken}}"
+									"value": "{{marketoAccessToken}}"
 								},
 								{
 									"key": "nextPageToken",
@@ -780,23 +928,69 @@
 								},
 								{
 									"key": "activityTypeIds",
-									"value": "7"
-								},
-								{
-									"key": "",
-									"value": ""
-								},
-								{
-									"key": null,
-									"value": null
-								},
-								{
-									"key": "",
-									"value": null
+									"value": "{{campaignEmailSent}}"
 								}
 							]
 						},
 						"description": "Verifying that marketo has attempted to send emails within the **last hour**."
+					},
+					"response": []
+				},
+				{
+					"name": "Get lead email address updated",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "c9f0ac6a-546d-482f-8f18-ce16a9b6e13d",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "29535b0a-7fee-42ef-8c79-2bcc5a383f94",
+								"exec": [
+									"const assert = eval(globals.loadAsserts);",
+									"assert.common(200, 1000, false, null, \"\");",
+									"",
+									"pm.test(\"Verify Lead email updated in Marketo\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.result[0].email).to.eql(pm.variables.get(\"newMarketoEmail\"));",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{marketoApi}}/rest/v1/lead/{{leadId}}.json?access_token={{marketoAccessToken}}&fields=email",
+							"host": [
+								"{{marketoApi}}"
+							],
+							"path": [
+								"rest",
+								"v1",
+								"lead",
+								"{{leadId}}.json"
+							],
+							"query": [
+								{
+									"key": "access_token",
+									"value": "{{marketoAccessToken}}"
+								},
+								{
+									"key": "fields",
+									"value": "email"
+								}
+							]
+						}
 					},
 					"response": []
 				}

--- a/tests/API_smoke_test.postman_collection.json
+++ b/tests/API_smoke_test.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "35e23581-413f-4acb-9c66-8865e59ea1cf",
+		"_postman_id": "f44f7047-0f3d-47ef-879f-9c17c7580a5e",
 		"name": "API_smoke_test",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -456,6 +456,367 @@
 					"listen": "test",
 					"script": {
 						"id": "3c4b721d-fa7b-47fd-9afa-a3e644e52681",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			],
+			"protocolProfileBehavior": {}
+		},
+		{
+			"name": "User Marketing Communication",
+			"item": [
+				{
+					"name": "Retrieve marketing acess token",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "b756b5be-319a-406c-ba54-31f8bef6a739",
+								"exec": [
+									"const assert = eval(globals.loadAsserts);",
+									"assert.common(200, 1000, false, null, \"\");",
+									"",
+									"pm.test(\"Set Access Token\", function () {",
+									"    let jsonData = pm.response.json();",
+									"    pm.variables.set(\"accessToken\", jsonData.access_token);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "https://248-ISZ-536.mktorest.com/identity/oauth/token?grant_type=client_credentials&client_id={{marketoClientId}}&client_secret={{marketoClientSecret}}",
+							"protocol": "https",
+							"host": [
+								"248-ISZ-536",
+								"mktorest",
+								"com"
+							],
+							"path": [
+								"identity",
+								"oauth",
+								"token"
+							],
+							"query": [
+								{
+									"key": "grant_type",
+									"value": "client_credentials"
+								},
+								{
+									"key": "client_id",
+									"value": "{{marketoClientId}}"
+								},
+								{
+									"key": "client_secret",
+									"value": "{{marketoClientSecret}}"
+								}
+							]
+						},
+						"description": "Retrieve unique access token from marketo. This token is valid for only **1 hour**."
+					},
+					"response": []
+				},
+				{
+					"name": "Retrieve paging token for the last 12 hours",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "3afd1793-633f-4d4c-8e4a-1f43a203a145",
+								"exec": [
+									"var moment = require('moment');\r",
+									"\r",
+									"    pm.variables.set(\"current_timestamp\", moment().format());\r",
+									"    pm.variables.set(\"last12Hours\", moment().subtract(12, 'hours').format());"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "598e2d2f-3f9d-4440-a3bc-4b3a0dccbf5f",
+								"exec": [
+									"const assert = eval(globals.loadAsserts);",
+									"assert.common(200, 1000, false, null, \"\");",
+									"",
+									"pm.test(\"Set Next Page Token for Last 12 Hours\", function (){",
+									"    let jsonData = pm.response.json();",
+									"    pm.variables.set(\"nextPageToken\", jsonData.nextPageToken);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "https://248-ISZ-536.mktorest.com/rest/v1/activities/pagingtoken.json?sinceDatetime={{last12Hours}}&access_token={{accessToken}}",
+							"protocol": "https",
+							"host": [
+								"248-ISZ-536",
+								"mktorest",
+								"com"
+							],
+							"path": [
+								"rest",
+								"v1",
+								"activities",
+								"pagingtoken.json"
+							],
+							"query": [
+								{
+									"key": "sinceDatetime",
+									"value": "{{last12Hours}}"
+								},
+								{
+									"key": "access_token",
+									"value": "{{accessToken}}"
+								}
+							]
+						},
+						"description": "returning paging token for last 12 hours in order to get lead changes in the following request"
+					},
+					"response": []
+				},
+				{
+					"name": "Verify new lead activity",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "0d6e3c86-77eb-42e6-965b-c446e0d0d1c2",
+								"exec": [
+									"const assert = eval(globals.loadAsserts);",
+									"assert.common(200, 1000, false, null, \"\");",
+									"",
+									"pm.test(\"User created within last 12 Hours\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.result[0].activityTypeId).to.eql(12);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "https://248-ISZ-536.mktorest.com/rest/v1/activities.json?access_token={{accessToken}}&nextPageToken={{nextPageToken}}&activityTypeIds=12&=&&",
+							"protocol": "https",
+							"host": [
+								"248-ISZ-536",
+								"mktorest",
+								"com"
+							],
+							"path": [
+								"rest",
+								"v1",
+								"activities.json"
+							],
+							"query": [
+								{
+									"key": "access_token",
+									"value": "{{accessToken}}"
+								},
+								{
+									"key": "nextPageToken",
+									"value": "{{nextPageToken}}"
+								},
+								{
+									"key": "activityTypeIds",
+									"value": "12"
+								},
+								{
+									"key": "",
+									"value": ""
+								},
+								{
+									"key": null,
+									"value": null
+								},
+								{
+									"key": "",
+									"value": null
+								}
+							]
+						},
+						"description": "making sure new users have been added to the marketo database wihthin the last 12 hours"
+					},
+					"response": []
+				},
+				{
+					"name": "Retrieve paging token for the last hour",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "3afd1793-633f-4d4c-8e4a-1f43a203a145",
+								"exec": [
+									"\r",
+									"var moment = require('moment');\r",
+									"\r",
+									"    pm.variables.set(\"current_timestamp\", moment().format());\r",
+									"    pm.variables.set(\"pastHour\", moment().subtract(1, 'hour').format());"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "598e2d2f-3f9d-4440-a3bc-4b3a0dccbf5f",
+								"exec": [
+									"const assert = eval(globals.loadAsserts);",
+									"assert.common(200, 1000, false, null, \"\");",
+									"",
+									"pm.test(\"Set Next Page Token for Last 12 Hours\", function (){",
+									"    let jsonData = pm.response.json();",
+									"    pm.variables.set(\"nextPageToken\", jsonData.nextPageToken);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "https://248-ISZ-536.mktorest.com/rest/v1/activities/pagingtoken.json?sinceDatetime={{pastHour}}&access_token={{accessToken}}",
+							"protocol": "https",
+							"host": [
+								"248-ISZ-536",
+								"mktorest",
+								"com"
+							],
+							"path": [
+								"rest",
+								"v1",
+								"activities",
+								"pagingtoken.json"
+							],
+							"query": [
+								{
+									"key": "sinceDatetime",
+									"value": "{{pastHour}}"
+								},
+								{
+									"key": "access_token",
+									"value": "{{accessToken}}"
+								}
+							]
+						},
+						"description": "returning paging token for last hour in order to get lead changes in the following request"
+					},
+					"response": []
+				},
+				{
+					"name": "Verify campaign emails being sent",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "9cbc4390-0752-4a23-b367-ea827ffd6f87",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "cacd1abb-0016-4dbd-875d-fa5dd33c1a4e",
+								"exec": [
+									"const assert = eval(globals.loadAsserts);",
+									"assert.common(200, 1000, false, null, \"\");",
+									"",
+									"pm.test(\"Marketo has delivered emails within the last hour\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.result).to.be.an('array').that.is.not.empty;",
+									"});",
+									"",
+									"   "
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "https://248-ISZ-536.mktorest.com/rest/v1/activities.json?access_token={{accessToken}}&nextPageToken={{nextPageToken}}&activityTypeIds=7&=&&",
+							"protocol": "https",
+							"host": [
+								"248-ISZ-536",
+								"mktorest",
+								"com"
+							],
+							"path": [
+								"rest",
+								"v1",
+								"activities.json"
+							],
+							"query": [
+								{
+									"key": "access_token",
+									"value": "{{accessToken}}"
+								},
+								{
+									"key": "nextPageToken",
+									"value": "{{nextPageToken}}"
+								},
+								{
+									"key": "activityTypeIds",
+									"value": "7"
+								},
+								{
+									"key": "",
+									"value": ""
+								},
+								{
+									"key": null,
+									"value": null
+								},
+								{
+									"key": "",
+									"value": null
+								}
+							]
+						},
+						"description": "Verifying that marketo has attempted to send emails within the **last hour**."
+					},
+					"response": []
+				}
+			],
+			"description": "A series of tests designed around making sure new clinicians and DSAs are being connected via shoreline to our marketing campaigns.",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "1aa215b0-df87-4014-b78a-0236be1b78af",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"id": "07c5ca86-781b-4d89-8ac9-296f79157d76",
 						"type": "text/javascript",
 						"exec": [
 							""

--- a/tests/PRODUCTION.postman_environment.json
+++ b/tests/PRODUCTION.postman_environment.json
@@ -1,38 +1,53 @@
 {
 	"id": "80228fb8-9308-47cb-b554-2f7a3b52309b",
 	"name": "PRODUCTION",
-	"values": [
-		{
-			"key": "api",
-			"value": "https://api.tidepool.org",
-			"enabled": true
-		},
-		{
-			"key": "loginEmail",
-			"value": "from-environment",
-			"enabled": true
-		},
-		{
-			"key": "loginPw",
-			"value": "from-environment",
-			"enabled": true
-		},
-		{
-			"key": "sharingEmailName",
-			"value": "jamie",
-			"enabled": true
-		},
-		{
-			"key": "marketoClientId",
-			"value": "from-environment",
-			"enabled": true
-		},
-		{
-			"key": "marketoClientSecret",
-			"value": "from-environment",
-			"enabled": true
-		}
-	],
+  "values": [
+    {
+      "key": "api",
+      "value": "https://api.tidepool.org",
+      "enabled": true
+    },
+    {
+      "key": "loginEmail",
+      "value": "from-environment",
+      "enabled": true
+    },
+    {
+      "key": "loginPw",
+      "value": "from-environment",
+      "enabled": true
+    },
+    {
+      "key": "sharingEmailName",
+      "value": "jamie",
+      "enabled": true
+    },
+    {
+      "key": "marketoClientId",
+      "value": "from-environment",
+      "enabled": true
+    },
+    {
+      "key": "marketoClientSecret",
+      "value": "from-environment",
+      "enabled": true
+    },
+    {
+      "key": "marketoApi",
+      "value": "https://248-ISZ-536.mktorest.com",
+      "enabled": true
+    },
+    {
+      "key": "leadId",
+      "value": "57149",
+      "enabled": true
+    },
+    {
+      "key": "marketoEmailPw",
+      "value": "from-environment",
+      "enabled": true
+    }
+  ],
 	"_postman_variable_scope": "environment",
 	"_postman_exported_at": "2020-03-20T23:54:33.214Z",
 	"_postman_exported_using": "Postman/7.20.1"

--- a/tests/PRODUCTION.postman_environment.json
+++ b/tests/PRODUCTION.postman_environment.json
@@ -39,7 +39,7 @@
     },
     {
       "key": "leadId",
-      "value": "57149",
+      "value": "63330",
       "enabled": true
     },
     {

--- a/tests/PRODUCTION.postman_environment.json
+++ b/tests/PRODUCTION.postman_environment.json
@@ -1,5 +1,5 @@
 {
-	"id": "be04540a-4f93-45a4-8ff0-2cbdb4716856",
+	"id": "80228fb8-9308-47cb-b554-2f7a3b52309b",
 	"name": "PRODUCTION",
 	"values": [
 		{
@@ -21,9 +21,19 @@
 			"key": "sharingEmailName",
 			"value": "jamie",
 			"enabled": true
+		},
+		{
+			"key": "marketoClientId",
+			"value": "from-environment",
+			"enabled": true
+		},
+		{
+			"key": "marketoClientSecret",
+			"value": "from-environment",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2020-01-12T20:58:43.926Z",
-	"_postman_exported_using": "Postman/7.14.0-canary01"
+	"_postman_exported_at": "2020-03-20T23:54:33.214Z",
+	"_postman_exported_using": "Postman/7.20.1"
 }

--- a/tests/QA1.postman_environment.json
+++ b/tests/QA1.postman_environment.json
@@ -31,7 +31,22 @@
 			"key": "marketoClientSecret",
 			"value": "from-environment",
 			"enabled": true
-		}
+		},
+	  {
+      "key": "marketoApi",
+      "value": "https://248-ISZ-536.mktorest.com",
+      "enabled": true
+    },
+    {
+      "key": "leadId",
+      "value": "57164",
+      "enabled": true
+    },
+    {
+      "key": "marketoEmailPw",
+      "value": "from-environment",
+      "enabled": true
+    }
 	],
 	"_postman_variable_scope": "environment",
 	"_postman_exported_at": "2020-03-20T23:54:51.225Z",

--- a/tests/QA1.postman_environment.json
+++ b/tests/QA1.postman_environment.json
@@ -1,5 +1,5 @@
 {
-	"id": "be04540a-4f93-45a4-8ff0-2cbdb4716856",
+	"id": "fd324800-2f50-4a1c-a69c-13b871693511",
 	"name": "QA1",
 	"values": [
 		{
@@ -21,9 +21,14 @@
 			"key": "sharingEmailName",
 			"value": "jamie",
 			"enabled": true
+		},
+		{
+			"key": "marketoClientId",
+			"value": "from-environment",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2020-01-12T20:58:43.926Z",
-	"_postman_exported_using": "Postman/7.14.0-canary01"
+	"_postman_exported_at": "2020-03-20T23:54:51.225Z",
+	"_postman_exported_using": "Postman/7.20.1"
 }

--- a/tests/QA1.postman_environment.json
+++ b/tests/QA1.postman_environment.json
@@ -36,16 +36,6 @@
       "key": "marketoApi",
       "value": "https://248-ISZ-536.mktorest.com",
       "enabled": true
-    },
-    {
-      "key": "leadId",
-      "value": "57164",
-      "enabled": true
-    },
-    {
-      "key": "marketoEmailPw",
-      "value": "from-environment",
-      "enabled": true
     }
 	],
 	"_postman_variable_scope": "environment",

--- a/tests/QA1.postman_environment.json
+++ b/tests/QA1.postman_environment.json
@@ -26,6 +26,11 @@
 			"key": "marketoClientId",
 			"value": "from-environment",
 			"enabled": true
+		},
+		{
+			"key": "marketoClientSecret",
+			"value": "from-environment",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",

--- a/tests/QA2.postman_environment.json
+++ b/tests/QA2.postman_environment.json
@@ -36,16 +36,6 @@
 			"key": "marketoApi",
 			"value": "https://248-ISZ-536.mktorest.com",
 			"enabled": true
-		},
-		{
-			"key": "leadId",
-			"value": "57164",
-			"enabled": true
-		},
-		{
-			"key": "marketoEmailPw",
-			"value": "from-environment",
-			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",

--- a/tests/QA2.postman_environment.json
+++ b/tests/QA2.postman_environment.json
@@ -1,5 +1,5 @@
 {
-	"id": "be04540a-4f93-45a4-8ff0-2cbdb4716856",
+	"id": "fbdd8cea-ffa3-48e5-b209-5666348cbd54",
 	"name": "QA2",
 	"values": [
 		{
@@ -21,9 +21,19 @@
 			"key": "sharingEmailName",
 			"value": "jamie",
 			"enabled": true
+		},
+		{
+			"key": "marketoClientSecret",
+			"value": "from-environment",
+			"enabled": true
+		},
+		{
+			"key": "marketoClientId",
+			"value": "from-environment",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2020-01-12T20:58:43.926Z",
-	"_postman_exported_using": "Postman/7.14.0-canary01"
+	"_postman_exported_at": "2020-03-20T23:54:59.644Z",
+	"_postman_exported_using": "Postman/7.20.1"
 }

--- a/tests/QA2.postman_environment.json
+++ b/tests/QA2.postman_environment.json
@@ -31,6 +31,21 @@
 			"key": "marketoClientId",
 			"value": "from-environment",
 			"enabled": true
+		},
+		{
+			"key": "marketoApi",
+			"value": "https://248-ISZ-536.mktorest.com",
+			"enabled": true
+		},
+		{
+			"key": "leadId",
+			"value": "57164",
+			"enabled": true
+		},
+		{
+			"key": "marketoEmailPw",
+			"value": "from-environment",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",


### PR DESCRIPTION
Verifying if users are being added to marketing program via shoreline as well as if those users are being sent emails by checking the "activity type" recorded in the last 12 hours and 1 hour, respectively.

Added clientId and clientSecret variables to travis and travis.yaml. 

Ideally, we would create a user via Tidepool's API and verify it has been added to the database with Marketos, unfortunately it takes marketo 10+ minutes to add a user to their database, which is not reliable enough to run in this series of smoke tests. 

This current set of tests is reliable enough to make sure we still have communication with our users.